### PR TITLE
Add "esbonio.enableFixDirectiveCompletion" and completion middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can also run the installation command manually.
 ## Configuration options
 
 - `esbonio.enable`: Enable coc-esbonio extension, default: `true`
+- `esbonio.enableFixDirectiveCompletion`: Enable fix patch for `Directive` completion issue, default: `true`
 - `esbonio.server.pythonPath`: Custom python path with esbonio[lsp] installed (Absolute path), default: `""`
 - `esbonio.server.logLevel`: The level of log message to show in the log, default: `"error"`
 - `esbonio.server.logFilter`: A list of logger names to limit output from, type: array, default: `null`

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
           "default": true,
           "description": "Enable coc-esbonio extension"
         },
+        "esbonio.enableFixDirectiveCompletion": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable fix patch for `Directive` completion issue"
+        },
         "esbonio.server.pythonPath": {
           "scope": "window",
           "type": "string",


### PR DESCRIPTION
## Description

Unnecessary dots are inserted at the end of "directives" when completing them.

VSCode extension seems to be fine, but coc.nvim has this symptom.

Added a patch to adjust the textEdit.range.end.character returned by LS, since it seems to be wrong.

I've already added a dedicated setting to enable/disable it, just in case.

## "Completion" candidates

<img width="601" alt="1_candidates" src="https://user-images.githubusercontent.com/188642/115485596-0357ad00-a290-11eb-87b5-7a507994fc2b.png">

### [BAD] Before add feature (Completion done)

<img width="603" alt="2_before" src="https://user-images.githubusercontent.com/188642/115485615-0a7ebb00-a290-11eb-9f9d-7bc36f9eab21.png">

### [OK!] After add feature (Completion done)

<img width="834" alt="3_after" src="https://user-images.githubusercontent.com/188642/115485656-1b2f3100-a290-11eb-8cdc-146f21c7c3e5.png">

