### PR TITLE
fix: windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Plug 'yaegassy/coc-esbonio', {'do': 'yarn install --frozen-lockfile'}
 
 1. `esbonio.server.pythonPath` setting
 1. Current python3 environment (e.g. venv or system global)
-1. builtin `venv/bin/python` (Installation commands are also provided)
+1. builtin `venv/bin/python` or `venv/Scripts/python.exe` (Installation commands are also provided)
 
 ## Bult-in install
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@types/node": "^12.11.7",
     "@types/rimraf": "^3.0.0",
+    "@types/which": "2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "coc.nvim": "^0.0.80",
@@ -45,7 +46,8 @@
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "which": "^2.0.2"
   },
   "activationEvents": [
     "onLanguage:rst",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,23 +10,28 @@ import { ESBONIO_LS_VERSION } from './constant';
 
 const exec = util.promisify(child_process.exec);
 
-export async function esbonioLsInstall(context: ExtensionContext): Promise<void> {
+export async function esbonioLsInstall(pythonCommand: string, context: ExtensionContext): Promise<void> {
   const pathVenv = path.join(context.storagePath, 'esbonio', 'venv');
-  const pathPip = path.join(pathVenv, 'bin', 'pip');
+
+  let pathVenvPython = path.join(context.storagePath, 'esbonio', 'venv', 'bin', 'python');
+  if (process.platform === 'win32') {
+    pathVenvPython = path.join(context.storagePath, 'esbonio', 'venv', 'Scripts', 'python');
+  }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
-  statusItem.text = `Install esbonio[lsp] ...`;
+  statusItem.text = `Install esbonio[lsp]...`;
   statusItem.show();
 
   const installCmd =
-    `python3 -m venv ${pathVenv} && ` + `${pathPip} install -U pip 'esbonio[lsp]'==${ESBONIO_LS_VERSION}`;
+    `${pythonCommand} -m venv ${pathVenv} && ` +
+    `${pathVenvPython} -m pip install -U pip esbonio[lsp]==${ESBONIO_LS_VERSION}`;
 
   rimraf.sync(pathVenv);
   try {
-    window.showWarningMessage(`Install esbonio[lsp]...`);
+    window.showMessage(`Install esbonio[lsp]...`);
     await exec(installCmd);
     statusItem.hide();
-    window.showWarningMessage(`esbonio[lsp]: installed!`);
+    window.showMessage(`esbonio[lsp]: installed!`);
   } catch (error) {
     statusItem.hide();
     window.showErrorMessage(`esbonio[lsp]: install failed. | ${error}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/which@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.0.tgz#446d35586611dee657120de8e0457382a658fc25"
+  integrity sha512-JHTNOEpZnACQdsTojWggn+SQ8IucfqEhtz7g8Z0G67WdSj4x3F0X5I2c/CVcl8z/QukGrIHeQ/N49v1au74XFQ==
+
 "@typescript-eslint/eslint-plugin@^4.8.2":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
@@ -1081,7 +1086,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
- Fix path of venv on windows (Change to Scripts instead of bin.)
- Change the installation procedure to `python -m pip` instead of using pip in venv directly.
- Remove single quotes for packages to be installed.
  - From: `'esbonio[lsp]'==0.5.1` -> To: `esbonio[lsp]==0.5.1`
- Added python3 and python command detection (since python3 commands may not be present on Windows and other special environments).