### PR TITLE
fix: Add stop and start for client when reinstalling language server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -178,7 +178,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   subscriptions.push(
     commands.registerCommand('esbonio.languageServer.install', async () => {
+      if (client.serviceState !== 5) {
+        await client.stop();
+      }
       await installWrapper(pythonCommand, context);
+      client.start();
     })
   );
 


### PR DESCRIPTION
There was a problem that reinstallation could not be completed properly depending on the environment (e.g. "Windows").