### PR TITLE
chore: bump esbonio to v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-esbonio",
   "version": "0.4.3",
-  "esbonioLsVersion": "0.6.0",
+  "esbonioLsVersion": "0.6.1",
   "description": "esbonio ([Sphinx] Python Documentation Generator) language server extension for coc.nvim",
   "author": "yaegassy <yosstools@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Close https://github.com/yaegassy/coc-esbonio/issues/6

A problem that prevented lint from working on some "Windows" systems has been fixed.

See below for other updates.

**REF**:

- <https://github.com/swyddfa/esbonio/releases/tag/esbonio-language-server-v0.6.1>