### PR TITLE
Align to changes in Esbonio's startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 Plug 'yaegassy/coc-esbonio', {'do': 'yarn install --frozen-lockfile'}
 ```
 
-## Detect: esbonio[lsp]
+## Detect: esbonio
 
 1. `esbonio.server.pythonPath` setting
 1. Current python3 environment (e.g. venv or system global)
@@ -34,9 +34,9 @@ Plug 'yaegassy/coc-esbonio', {'do': 'yarn install --frozen-lockfile'}
 
 ## Bult-in install
 
-coc-esbonio allows you to create an extension-only "venv" and install "esbonio[lsp]".
+coc-esbonio allows you to create an extension-only "venv" and install "esbonio".
 
-The first time you use coc-esbonio, if esbonio[lsp] is not detected, you will be prompted to do a built-in installation.
+The first time you use coc-esbonio, if esbonio is not detected, you will be prompted to do a built-in installation.
 
 You can also run the installation command manually.
 
@@ -56,7 +56,7 @@ You can also run the installation command manually.
 - `esbonio.client.sectionCharacterLevel1`: Character to be used in the Section builder (level1) of the code action, default: `"="`,
 - `esbonio.client.sectionCharacterLevel2`: Character to be used in the Section builder (level2) of the code action, default: `"-"`,
 - `esbonio.client.sectionCharacterLevel3`: Character to be used in the Section builder (level3) of the code action, default: `"~"`,
-- `esbonio.server.pythonPath`: Custom python path with esbonio[lsp] installed (Absolute path), default: `""`
+- `esbonio.server.pythonPath`: Custom python path with esbonio installed (Absolute path), default: `""`
 - `esbonio.server.logLevel`: The level of log message to show in the log, default: `"error"`
 - `esbonio.server.logFilter`: A list of logger names to limit output from, type: array, default: `null`
 - `esbonio.server.hideSphinxOutput`: Hide Sphinx build output from the Language Server log, default: `false`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-esbonio",
   "version": "0.4.5",
-  "esbonioLsVersion": "0.6.1",
+  "esbonioLsVersion": "0.6.2",
   "description": "esbonio ([Sphinx] Python Documentation Generator) language server extension for coc.nvim",
   "author": "yaegassy <yosstools@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
           "scope": "window",
           "type": "string",
           "default": "",
-          "description": "Custom python path with esbonio[lsp] installed (Absolute path)"
+          "description": "Custom python path with esbonio installed (Absolute path)"
         },
         "esbonio.server.logLevel": {
           "scope": "application",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
   }
 
-  // Install "esbonio[lsp]" if it does not exist.
+  // Install "esbonio" if it does not exist.
   if (!esbonioServerPythonPath) {
     const isRealpath = true;
     const builtinInstallPythonCommand = getPythonCommand(isRealpath);
@@ -89,7 +89,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
   }
 
-  // If "esbonio[lsp]" does not exist completely, terminate the process.
+  // If "esbonio" does not exist completely, terminate the process.
   // ----
   // If you cancel the installation.
   if (!esbonioServerPythonPath) {
@@ -197,7 +197,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 }
 
 async function installWrapper(pythonCommand: string, context: ExtensionContext) {
-  const msg = 'Install/Upgrade "esbonio[lsp]"?';
+  const msg = 'Install/Upgrade "esbonio"?';
   context.workspaceState;
 
   let ret = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,30 +99,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   const isFixDirectiveCompletion = extensionConfig.get<boolean>('enableFixDirectiveCompletion', true);
 
-  const pythonArgs = [
-    '-m',
-    'esbonio',
-    '--cache-dir',
-    path.join(extensionStoragePath, 'sphinx'),
-    '--log-level',
-    extensionConfig.get<string>('server.logLevel', 'error'),
-  ];
-
-  if (extensionConfig.get<boolean>('server.hideSphinxOutput', false)) {
-    pythonArgs.push('--hide-sphinx-output');
-  }
-
-  const logFilters = extensionConfig.get<string[]>('server.logFilter', []);
-  if (logFilters) {
-    logFilters.forEach((filterName) => {
-      pythonArgs.push('--log-filter', filterName);
-    });
-  }
-
   const command = esbonioServerPythonPath;
   const serverOptions: ServerOptions = {
     command,
-    args: pythonArgs,
+    args: ['-m', 'esbonio'],
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -132,6 +112,18 @@ export async function activate(context: ExtensionContext): Promise<void> {
       // MEMO: but coc-esbonio sets only rst.
       //{ scheme: 'file', language: 'python' },
     ],
+    initializationOptions: {
+      sphinx: {
+        srcDir: extensionConfig.get<string>('sphinx.srcDir'),
+        confDir: extensionConfig.get<string>('sphinx.confDir'),
+        buildDir: path.join(extensionStoragePath, 'sphinx')
+      },
+      server: {
+        logLevel: extensionConfig.get<string>('server.logLevel', 'error'),
+        logFilter: extensionConfig.get<string[]>('server.logFilter', []),
+        hideSphinxOutput: extensionConfig.get<boolean>('server.hideSphinxOutput', false)
+      }
+    },
     outputChannelName: 'esbonio',
     middleware: {
       provideCompletionItem: async (

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -19,22 +19,22 @@ export async function esbonioLsInstall(pythonCommand: string, context: Extension
   }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
-  statusItem.text = `Install esbonio[lsp]...`;
+  statusItem.text = `Install esbonio...`;
   statusItem.show();
 
   const installCmd =
     `${pythonCommand} -m venv ${pathVenv} && ` +
-    `${pathVenvPython} -m pip install -U pip esbonio[lsp]==${ESBONIO_LS_VERSION}`;
+    `${pathVenvPython} -m pip install -U pip esbonio==${ESBONIO_LS_VERSION}`;
 
   rimraf.sync(pathVenv);
   try {
-    window.showMessage(`Install esbonio[lsp]...`);
+    window.showMessage(`Install esbonio...`);
     await exec(installCmd);
     statusItem.hide();
-    window.showMessage(`esbonio[lsp]: installed!`);
+    window.showMessage(`esbonio: installed!`);
   } catch (error) {
     statusItem.hide();
-    window.showErrorMessage(`esbonio[lsp]: install failed. | ${error}`);
+    window.showErrorMessage(`esbonio: install failed. | ${error}`);
     throw new Error();
   }
 }


### PR DESCRIPTION
In the [next release](https://github.com/swyddfa/esbonio/pull/206) of Esbonio there will be some changes to the way the language server is run

- Cli options like `--log-level` have been removed in favour of configuration values.
- The server's initial configuration should be passed in through the `initializationOptions` field of the `initialize` request

This PR makes the changes necessary to be compatible with the next version as well as removing the `[lsp]` extra from the `esbonio` Python package as this is no longer required.