### PR TITLE
feat: Add code actions (Insert Link and Insert Inline Link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - (Build in the cache directory)
 - Code Action by client feature
   - Section builder feature. [DEMO](https://github.com/yaegassy/coc-esbonio/pull/2)
+  - Insert link feature. [DEMO](https://github.com/yaegassy/coc-esbonio/pull/2)
 
 ## Install
 
@@ -67,6 +68,16 @@ You can also run the installation command manually.
 
 - `esbonio.languageServer.install`: Install/Upgrade Language Server
 - `esbonio.languageServer.restart`: Restart Language Server
+
+## Code Actions
+
+- `Section builder (level1)`
+- `Section builder (level2)`
+- `Section builder (level3)`
+- `Insert Link (cursol)`
+- `Insert Inline Link (cursol)`
+- `Insert Link (line & range)`
+- `Insert Inline Link (line & range)`
 
 ## Recommended setting
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,0 +1,140 @@
+import { commands, Document, ExtensionContext, Range, TextEdit, workspace, window, WorkspaceEdit } from 'coc.nvim';
+
+// **MEMO**:
+// Since coc.nvim does not have an vscode.EndOfLine equivalent,
+// I implemented it using Vim way.
+//
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function getEOLSequence(): Promise<string> {
+  // default: '\n'
+  const eol = '\n';
+
+  const fileFormat = await workspace.nvim.getOption('fileformat');
+  window.showMessage(`${fileFormat}`);
+  switch (fileFormat) {
+    case 'unix':
+      return '\n';
+    case 'dos':
+      return '\r\n';
+  }
+
+  return eol;
+}
+
+export class EditorCommands {
+  public static INSERT_LINK = 'esbonio.insert.link';
+  public static INSERT_INLINE_LINK = 'esbonio.insert.inlineLink';
+
+  ////LINK_PATTERN = /\.\.[ ]_\S+:[ ]\S+\n/;
+  LINK_PATTERN = /\.\.[ ]_\S+:[ ]\S+$/;
+
+  constructor() {}
+
+  /**
+   * Insert link.
+   */
+  async insertLink(range?: Range) {
+    const doc = await workspace.document;
+
+    const link = await this.getLinkInfo(doc, range);
+    if (!link.url || !link.label) {
+      return;
+    }
+
+    // MEMO: Set '\n' explicitly
+    //const eol = getEOLSequence();
+    const eol = '\n';
+
+    const lastLine = doc.lineCount - 1;
+    let lineText = doc.getline(lastLine);
+    const lastCharacter = lineText.length;
+
+    let prefix = '';
+    if (lineText.length === 0) {
+      lineText = doc.getline(doc.lineCount - 2);
+    } else {
+      prefix = eol;
+    }
+
+    if (!this.LINK_PATTERN.test(lineText)) {
+      prefix += eol;
+    }
+
+    const linkRef = `\`${link.label}\`_`;
+    const linkDef = `${prefix}.. _${link.label}: ${link.url}${eol}`;
+
+    if (!range) {
+      const state = await workspace.getCurrentState();
+      range = Range.create(state.position, state.position);
+    }
+
+    const edit: WorkspaceEdit = {
+      changes: {
+        [doc.uri]: [
+          TextEdit.replace(range, linkRef),
+          TextEdit.insert({ line: lastLine, character: lastCharacter }, linkDef),
+        ],
+      },
+    };
+
+    await workspace.applyEdit(edit);
+  }
+
+  /**
+   * Insert inline link.
+   */
+  public async insertInlineLink(range?: Range) {
+    const doc = await workspace.document;
+
+    const link = await this.getLinkInfo(doc, range);
+    if (!link.url || !link.label) {
+      return;
+    }
+
+    const inlineLink = `\`${link.label} <${link.url}>\`_`;
+
+    if (!range) {
+      const state = await workspace.getCurrentState();
+      range = Range.create(state.position, state.position);
+    }
+
+    const edit: WorkspaceEdit = {
+      changes: {
+        [doc.uri]: [TextEdit.replace(range, inlineLink)],
+      },
+    };
+
+    await workspace.applyEdit(edit);
+  }
+
+  /**
+   * Register all the commands this class provides
+   */
+  register(context: ExtensionContext) {
+    context.subscriptions.push(
+      commands.registerCommand(EditorCommands.INSERT_INLINE_LINK, this.insertInlineLink, this, true)
+    );
+    context.subscriptions.push(commands.registerCommand(EditorCommands.INSERT_LINK, this.insertLink, this, true));
+  }
+
+  /**
+   * Helper function that returns the url to be linked and its label
+   */
+  private async getLinkInfo(doc: Document, range?: Range) {
+    let label: string;
+    const url = await window.requestInput('Link URL', 'https://');
+
+    if (!range) {
+      const state = await workspace.getCurrentState();
+      range = Range.create(state.position, state.position);
+      label = await window.requestInput('Link Text', '');
+    } else {
+      label = doc.textDocument.getText(range);
+    }
+
+    return {
+      label: label,
+      url: url,
+    };
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import semver from 'semver';
 
 import { esbonioLsInstall } from './installer';
 import { EsbonioCodeActionProvider } from './action';
+import { EditorCommands } from './command';
 
 const exec = util.promisify(child_process.exec);
 
@@ -226,6 +227,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     languages.registerCodeActionProvider([{ scheme: 'file', language: 'rst' }], codeActionProvider, 'esbonio')
   );
+
+  const editorCommand = new EditorCommands();
+  editorCommand.register(context);
 }
 
 async function installWrapper(pythonCommand: string, context: ExtensionContext) {


### PR DESCRIPTION
## DEMO

![coc-esbonio-insert-link-action](https://user-images.githubusercontent.com/188642/120401131-41112080-c37a-11eb-81b3-843ef8247e95.gif)

## Description

It is provided as a "Command" in esbonio's vscode extension, but implemented as a "Code Action" in coc-esbonio.

Passing "Range" and executing `:CocCommand` because it is hard to handle in `coc.nvim`.

