### PR TITLE
User anonymous references when inserting inline links

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -90,7 +90,7 @@ export class EditorCommands {
       return;
     }
 
-    const inlineLink = `\`${link.label} <${link.url}>\`_`;
+    const inlineLink = `\`${link.label} <${link.url}>\`__`;
 
     if (!range) {
       const state = await workspace.getCurrentState();


### PR DESCRIPTION
Hi, thanks for creating this extension!

When using an inline link, you usually want to use
an anonymous reference, not a named one.

> With a single trailing underscore, the reference is named and the same
> target URI may be referred to again. With two trailing underscores, the
> reference and target are both anonymous, and the target cannot be
> referred to again. These are "one-off" hyperlinks. For example:

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases

This avoids unexpected collisions with other explicitly named references.